### PR TITLE
Deduplicte endpoint urls

### DIFF
--- a/scripts/start-firehose.sh
+++ b/scripts/start-firehose.sh
@@ -80,7 +80,7 @@ done
 
 cat /config/hashtag-urls.txt >> /config/urls.txt
 
-cat /config/urls.txt | while read -r url
+sort -u /config/urls.txt | while read -r url
 do
    echo "[INFO] Opening $url to stream"
    sleep $streamDelay

--- a/scripts/start-firehose.sh
+++ b/scripts/start-firehose.sh
@@ -82,9 +82,12 @@ cat /config/hashtag-urls.txt >> /config/urls.txt
 
 sort -u /config/urls.txt | while read -r url
 do
-   echo "[INFO] Opening $url to stream"
-   sleep $streamDelay
-   ./stream-url.sh $url &
+   if [[ ! $url == "#"* ]]
+   then 
+      echo "[INFO] Opening $url to stream"
+      sleep $streamDelay
+      ./stream-url.sh $url &
+   fi 
 done
 
 if [[ $runFirehose == true ]]

--- a/scripts/start-firehose.sh
+++ b/scripts/start-firehose.sh
@@ -2,6 +2,7 @@
 
 echo > /config/urls.txt
 echo > /config/hosts
+echo > /config/hashtag-urls.txt
 
 # Get federated hosts and begin to stream them
 cat /config/domains-federated | grep -v "##" | while read -r line


### PR DESCRIPTION
Each time `start-firehouse.sh` starts, new duplicate lines are added into `/config/hashtag-urls.txt`. 

This patch solve this by resetting the file on each start, and also make sure that we never pass duplicate urls to `stream-url.sh` in case of misconfiguration. 

It also make sure that urls that start with "#" never is sent to `stream-url.sh`, in case of incorrect (traditional) single hashtag comments in config.